### PR TITLE
Add cloudbuild files

### DIFF
--- a/api/cloudbuild.master.yaml
+++ b/api/cloudbuild.master.yaml
@@ -1,0 +1,21 @@
+steps:
+  - name: node:12-alpine
+    id: ci
+    dir: api
+    entrypoint: npm
+    args: ['ci']
+
+  - name: node:12-alpine
+    dir: api
+    entrypoint: npm
+    args: ['test']
+
+  - name: gcr.io/kaniko-project/executor:debug
+    dir: 'api'
+    args:
+      - '--destination=gcr.io/$PROJECT_ID/api:$BRANCH_NAME-$SHORT_SHA'
+      - '--destination=gcr.io/$PROJECT_ID/api:latest'
+      - '--dockerfile=./Dockerfile'
+      - '--reproducible'
+      - '--cache=true'
+      - '--cache-ttl=6h'

--- a/api/cloudbuild.yaml
+++ b/api/cloudbuild.yaml
@@ -1,0 +1,11 @@
+steps:
+  - name: node:12-alpine
+    id: ci
+    dir: api
+    entrypoint: npm
+    args: ['ci']
+
+  - name: node:12-alpine
+    dir: api
+    entrypoint: npm
+    args: ['test']


### PR DESCRIPTION
Doing two cloudbuild files seems like a way to keep the cloudbuild steps
simple. Separate triggers have been created.