### PR TITLE
Build with Docker instead of Kaniko

### DIFF
--- a/frontend/cloudbuild.yaml
+++ b/frontend/cloudbuild.yaml
@@ -11,12 +11,10 @@ steps:
     dir: frontend
     entrypoint: npm
     args: ['test']
-    env:
 
-  - name: gcr.io/kaniko-project/executor
+  - name: 'gcr.io/cloud-builders/docker'
     id: build
     dir: frontend
-    args:
-      - --destination=gcr.io/$PROJECT_ID/frontend:$BRANCH_NAME-$SHORT_SHA
-      - --destination=gcr.io/$PROJECT_ID/frontend:latest
-      - --reproducible
+    args: ['build', '-t','gcr.io/$PROJECT_ID/frontend:$BRANCH_NAME-$SHORT_SHA', '.']
+
+images: ['gcr.io/$PROJECT_ID/frontend:$BRANCH_NAME-$SHORT_SHA']


### PR DESCRIPTION
Mysterious build errors and a lack of multistage builds are a bit
off-putting. Try again later.