### PR TITLE
Add node_modules to dockerignore

### DIFF
--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -5,3 +5,4 @@
 **/*.swo
 **/*.swx
 **/*.js~
+node_modules


### PR DESCRIPTION
This speeds up the builds and is getting regenerated within the image
anyway.